### PR TITLE
fix: Automatic TPM/RPM Cooldowns (GOV-011)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+node_modules/
+.git/
+extracted_repos/
+*.log

--- a/src/index.js
+++ b/src/index.js
@@ -218,7 +218,7 @@ class Governor {
         // Status Determination
         if (autonomyBudget <= 0) {
             return { status: 'RED', reason: 'throttled_or_reserve', autonomyBudget, mode: hourConfig.mode };
-        } else if (autonomyBudget < 5) {
+        } else if (autonomyBudget < 10) {
             return { status: 'YELLOW', reason: 'low_budget', autonomyBudget, mode: hourConfig.mode };
         } else {
             return { status: 'GREEN', reason: 'good', autonomyBudget, mode: hourConfig.mode };
@@ -243,7 +243,7 @@ class Governor {
         state.config.currentUsage.thisMinute = state.config.currentUsage.requestLog.length;
         
         if (!state.config.currentUsage.tpmUsed) state.config.currentUsage.tpmUsed = 0;
-        state.config.currentUsage.tpmUsed += tokens;
+        state.config.currentUsage.tpmUsed += tokens; if (state.config.currentUsage.tpmUsed > (this.TPM_LIMIT * 0.95)) { state.config.currentUsage.shouldPause = true; }
 
         state.config.currentUsage.lastReset = new Date().toISOString(); 
         

--- a/src/utils/backoff.js
+++ b/src/utils/backoff.js
@@ -1,0 +1,3 @@
+module.exports = async function pause(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+};


### PR DESCRIPTION
Closes #28. 
- Increased YELLOW threshold to 10 units for earlier caution.
- Added 'shouldPause' signal to incrementUsage for predictive throttling.
- Added async backoff utility for worker loops.